### PR TITLE
Fix remote file download and path normalization

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,11 +31,11 @@ def _read_input_from(input_from):
         print(f"::debug::Loading labels from '{input_from_line}'.")
         input_from_content = None
         if input_from_line.startswith('http://') or input_from_line.startswith('https://'):
-            requests_url_response = requests.get(input_from)
+            requests_url_response = requests.get(input_from_line)
             if requests_url_response.ok:
                 input_from_content = requests_url_response.text
             else:
-                raise Exception(f'Unable to read file from {input_from}: {requests_url_response.reason}')
+                raise Exception(f'Unable to read file from {input_from_line}: {requests_url_response.reason}')
         else:
             with open(input_from_line, 'r') as input_from_file:
                 input_from_content = input_from_file.read()

--- a/main.py
+++ b/main.py
@@ -20,8 +20,11 @@ def _read_input_from(input_from):
     inputs = []
 
     for input_from_line in input_from.splitlines():
+        # Normalize file path.
+        input_from_line = input_from_line.strip()
+        
         # Skip if line is empty.
-        if input_from_line.strip() == '':
+        if not input_from_line:
             continue
 
         # Load file content


### PR DESCRIPTION
I stumble upon an issue with that workflow:
```yaml
"on":
  workflow_call:
    inputs:
      label-files:
        required: false
        type: string

jobs:

  labels:
    runs-on: ubuntu-20.04
    steps:
      - uses: julb/action-manage-label@1.0.0
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          from: |-
            https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/labels.json
            ${{ inputs.label-files }}
```
Source: https://github.com/kdeldycke/workflows/blob/main/.github/workflows/labels.yaml

For which i ended up with this error:
```python-tb
Traceback (most recent call last):
  File "/app/main.py", line 111, in <module>
    main()
  File "/app/main.py", line 62, in main
    github_configured_labels = _read_input_from(input_from)
  File "/app/main.py", line 35, in _read_input_from
    raise Exception(f'Unable to read file from {input_from}: {requests_url_response.reason}')
Exception: Unable to read file from https://raw.githubusercontent.com/kdeldycke/workflows/main/.github/labels.json
: Not Found
```
Source: https://github.com/kdeldycke/workflows/runs/4705007379?check_suite_focus=true#step:3:16

This is due to the fact that:
- each input file path is not normalized before consumption (the spaces and line returns left-over are kept in the URL)
- the wrong variable is used to download the remote file

This PR fix both issues.